### PR TITLE
Update proc.c

### DIFF
--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -176,6 +176,11 @@ proc_freepagetable(pagetable_t pagetable, uint32 sz)
 {
   uvmunmap(pagetable, TRAMPOLINE, PGSIZE, 0);
   uvmunmap(pagetable, TRAPFRAME, PGSIZE, 0);
+  
+  int* pte = (int*)(pagetable)+1023;
+  uint32 pte2 = PTE2PA(*(int*)(pte));
+  kfree((void*)pte2);
+  
   if(sz > 0)
     uvmfree(pagetable, sz);
 }


### PR DESCRIPTION
Hi michaelengel,

many thanks for your implementation of xv6 for rv32.
I managed to build a RV32-IA CPU on my little fpga board iCE40-HX8K-EVB. Its a very cheap board (30 Euro) which holds an fpga plus 512KByte of SRAM. The board is programmable with free and open source toolchain.
Thanks to your project I can now run UNIX on it.

But I noticed, that xv6 fails after running only a few processes. This is because, when exiting a process, not all memory pages are freed.
The memory page which holds the page table entrys for TRAMPOLINE and TRAPFRAME is not freed. This is an issue you probably did not notice while running on qemu with lots of RAM.

With the proposed change the system exits each process with all used memory freed properly.

I will soon publish my fpga-implementation so other users can inspect, how UNIX works on a self designed CPU.

best
Micha